### PR TITLE
Fix: actually create/delete HSM groups without crashing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde_yaml = "0.9.17"
 log = "0.4.17"
 # env_logger = "0.9.0" # Changing to log4rs because we also need to log in files for auditing
 log4rs = "1.2.0" # Docs about pattern encoder https://docs.rs/log4rs/0.10.0/log4rs/encode/pattern/index.html
-tokio = { version = "1" }
+tokio = { version = "1", features = ["full"]}
 tokio-rustls = "0.24.0" # used by kube-rs to configure client with socks proxy -- REMOVE
 # tokio-native-tls = "0.3.0" # used by kube-rs to configure client with socks proxy -- REMOVE
 tokio-util = "0.7.4"       # used by manta_console to create a read stream from container stdout

--- a/src/hsm.rs
+++ b/src/hsm.rs
@@ -16,6 +16,7 @@ pub mod group {
             pub members: Option<Member>,
             #[serde(skip_serializing_if = "Option::is_none")]
             #[serde(rename(serialize = "exclusiveGroup"))]
+            #[serde(rename(deserialize = "exclusiveGroup"))]
             pub exclusive_group: Option<String>,
         }
 

--- a/src/hsm.rs
+++ b/src/hsm.rs
@@ -306,16 +306,6 @@ pub mod group {
 
             let url_api = shasta_base_url.to_owned() + "/smd/hsm/v2/groups";
 
-            // let result = client
-            //     .post(url_api)
-            //     .header("Authorization", format!("Bearer {}", shasta_token))
-            //     .json(&hsm_group_json) // make sure this is not a string!
-            //     .send()
-            //     .await
-            //     .expect("failed to get response")
-            //     .text()
-            //     .await
-            //     .expect("failed to get payload");
             let result = match client
                 .post(url_api)
                 .header("Authorization", format!("Bearer {}", shasta_token))
@@ -325,22 +315,18 @@ pub mod group {
                 .error_for_status()?
                 .text()
                 .await {
-
+                // If we get here, there must have been an error parsing the result.
+                // Other returns from the API should be caught by error_for_status() and pushed back
+                // with the ? at the end of it.
                 Ok(_res) => {
-                    println!("Result:{}",_res);
                     _res
                 },
                 Err(e) => {
-                    println!("error: {}", e);
                     return Ok(vec![hsm_group_json])
                 }
             };
+
             Ok(vec![hsm_group_json])
-
-            // // if we reach this point, the previous call hasn't bailed on us
-            // println!("Result: {:?}",result);
-            // Ok(vec![hsm_group_json])
-
         }
 
         pub async fn delete_hsm_group(

--- a/src/hsm.rs
+++ b/src/hsm.rs
@@ -306,18 +306,41 @@ pub mod group {
 
             let url_api = shasta_base_url.to_owned() + "/smd/hsm/v2/groups";
 
-            let result = client
+            // let result = client
+            //     .post(url_api)
+            //     .header("Authorization", format!("Bearer {}", shasta_token))
+            //     .json(&hsm_group_json) // make sure this is not a string!
+            //     .send()
+            //     .await
+            //     .expect("failed to get response")
+            //     .text()
+            //     .await
+            //     .expect("failed to get payload");
+            let result = match client
                 .post(url_api)
                 .header("Authorization", format!("Bearer {}", shasta_token))
                 .json(&hsm_group_json) // make sure this is not a string!
                 .send()
                 .await?
-                // .expect("failed to get response")
+                .error_for_status()?
                 .text()
-                .await?;
-                // .expect("failed to get payload");
-            // if we reach this point, the previous call hasn't bailed on us
+                .await {
+
+                Ok(_res) => {
+                    println!("Result:{}",_res);
+                    _res
+                },
+                Err(e) => {
+                    println!("error: {}", e);
+                    return Ok(vec![hsm_group_json])
+                }
+            };
             Ok(vec![hsm_group_json])
+
+            // // if we reach this point, the previous call hasn't bailed on us
+            // println!("Result: {:?}",result);
+            // Ok(vec![hsm_group_json])
+
         }
 
         pub async fn delete_hsm_group(

--- a/src/hsm.rs
+++ b/src/hsm.rs
@@ -349,9 +349,13 @@ pub mod group {
                 .header("Authorization", format!("Bearer {}", shasta_token))
                 .send()
                 .await?
+                // .expect("failed to get response")
                 .error_for_status()?
-                .json()
-                .await
+                .text()
+                .await?;
+                // .expect("failed to get payload");
+            // if we reach this point, the previous call hasn't bailed on us
+            Ok("".to_string())
         }
     }
 

--- a/src/hsm.rs
+++ b/src/hsm.rs
@@ -298,7 +298,7 @@ pub mod group {
             }
 
             let mytags;
-            if tags.first().unwrap().is_empty() {
+            if tags.len() > 0 && tags.first().unwrap().is_empty() {
                 mytags = None;
             } else {
                 mytags = Some(tags.to_owned());


### PR DESCRIPTION
* Prevent that when some optional fields are empty, Mesa sends unacceptable JSON content to HSM
* When creating a new HSM group, CSM returns a text field, not a json. This made the function always fail, even when the creation was done successfully.